### PR TITLE
Add rods and region highlights

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:flutter_earth_globe/globe_coordinates.dart';
 import 'package:flutter_earth_globe/point.dart';
 import 'package:flutter_earth_globe/point_connection.dart';
 import 'package:flutter_earth_globe/point_connection_style.dart';
+import 'package:flutter_earth_globe/rod.dart';
+import 'package:flutter_earth_globe/region_highlight.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_earth_globe/sphere_style.dart';
 
@@ -47,6 +49,9 @@ class _HomeState extends State<Home> with TickerProviderStateMixin {
   late List<Point> points;
 
   List<PointConnection> connections = [];
+  late Rod exampleRod;
+  late RegionHighlight polygonRegion;
+  late RegionHighlight circleRegion;
 
   Widget pointLabelBuilder(
       BuildContext context, Point point, bool isHovering, bool visible) {
@@ -193,6 +198,29 @@ class _HomeState extends State<Home> with TickerProviderStateMixin {
     for (var point in points) {
       _controller.addPoint(point);
     }
+
+    exampleRod = Rod(
+        id: 'rod1',
+        start: points[0].coordinates,
+        end: points[2].coordinates,
+        color: Colors.purple,
+        stickOut: 15,
+        width: 3);
+    _controller.addRod(exampleRod);
+
+    polygonRegion = RegionHighlight.polygon(id: 'poly1', coordinates: [
+      const GlobeCoordinates(10, -20),
+      const GlobeCoordinates(15, -10),
+      const GlobeCoordinates(20, -20),
+    ], color: Colors.green.withOpacity(0.3));
+    _controller.addRegion(polygonRegion);
+
+    circleRegion = RegionHighlight.circle(
+        id: 'circle1',
+        center: const GlobeCoordinates(-20, 30),
+        radius: 10,
+        color: Colors.red.withOpacity(0.2));
+    _controller.addRegion(circleRegion);
 
     super.initState();
   }

--- a/lib/flutter_earth_globe_controller.dart
+++ b/lib/flutter_earth_globe_controller.dart
@@ -12,6 +12,8 @@ import 'sphere_style.dart';
 import 'point_connection.dart';
 
 import 'point_connection_style.dart';
+import 'rod.dart';
+import 'region_highlight.dart';
 
 /// This class is the controller of the [RotatingGlobe] widget.
 ///
@@ -26,6 +28,8 @@ class FlutterEarthGlobeController extends ChangeNotifier {
   List<Point> points = []; // The points on the globe.
   List<AnimatedPointConnection> connections =
       []; // The connections between points.
+  List<Rod> rods = []; // Rods going through the sphere.
+  List<RegionHighlight> regions = []; // Highlighted regions.
   SphereStyle sphereStyle; // The style of the sphere.
   ui.Image? surface; // The surface image of the sphere.
   ui.Image? background; // The background image of the sphere.
@@ -292,6 +296,80 @@ class FlutterEarthGlobeController extends ChangeNotifier {
   void removePoint(String id) {
     points.removeWhere((element) => element.id == id);
     notifyListeners();
+  }
+
+  /// Adds a [rod] that goes through the globe.
+  void addRod(Rod rod) {
+    rods.add(rod);
+    notifyListeners();
+  }
+
+  /// Removes the rod with the given [id].
+  void removeRod(String id) {
+    rods.removeWhere((element) => element.id == id);
+    notifyListeners();
+  }
+
+  /// Updates a rod by [id].
+  void updateRod(
+    String id, {
+    GlobeCoordinates? start,
+    GlobeCoordinates? end,
+    Color? color,
+    double? width,
+    double? stickOut,
+  }) {
+    final index = rods.indexWhere((element) => element.id == id);
+    if (index != -1) {
+      rods[index] = rods[index].copyWith(
+        start: start,
+        end: end,
+        color: color,
+        width: width,
+        stickOut: stickOut,
+      );
+      notifyListeners();
+    }
+  }
+
+  /// Adds a highlighted [region] to the globe.
+  void addRegion(RegionHighlight region) {
+    regions.add(region);
+    notifyListeners();
+  }
+
+  /// Removes a highlighted region by [id].
+  void removeRegion(String id) {
+    regions.removeWhere((element) => element.id == id);
+    notifyListeners();
+  }
+
+  /// Updates a highlighted region with [id].
+  void updateRegion(
+    String id, {
+    List<GlobeCoordinates>? coordinates,
+    double? radius,
+    Color? color,
+  }) {
+    final index = regions.indexWhere((element) => element.id == id);
+    if (index != -1) {
+      final r = regions[index];
+      if (r.type == RegionHighlightType.polygon) {
+        regions[index] = RegionHighlight.polygon(
+          id: r.id,
+          coordinates: coordinates ?? r.coordinates,
+          color: color ?? r.color,
+        );
+      } else {
+        regions[index] = RegionHighlight.circle(
+          id: r.id,
+          center: coordinates?.first ?? r.coordinates.first,
+          radius: radius ?? r.radius,
+          color: color ?? r.color,
+        );
+      }
+      notifyListeners();
+    }
   }
 
   /// Loads the [image] as the surface of the globe.

--- a/lib/foreground_painter.dart
+++ b/lib/foreground_painter.dart
@@ -4,6 +4,8 @@ import 'point.dart';
 import 'line_helper.dart';
 import 'math_helper.dart';
 import 'point_connection.dart';
+import 'rod.dart';
+import 'region_highlight.dart';
 
 import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart' as vector;
@@ -61,6 +63,8 @@ class ForegroundPainter extends CustomPainter {
     required this.rotationX,
     required this.zoomFactor,
     required this.points,
+    required this.rods,
+    required this.regions,
     this.hoverPoint,
     this.clickPoint,
     this.onPointClicked,
@@ -82,6 +86,8 @@ class ForegroundPainter extends CustomPainter {
   final double rotationX;
   final double zoomFactor;
   final List<Point> points;
+  final List<Rod> rods;
+  final List<RegionHighlight> regions;
 
   bool isSame(GlobeCoordinates c1, GlobeCoordinates c2) {
     return c1.latitude == c2.latitude && c1.longitude == c2.longitude;
@@ -92,6 +98,43 @@ class ForegroundPainter extends CustomPainter {
     final center = Offset(size.width / 2, size.height / 2);
     final localHover = hoverPoint;
     final localClick = clickPoint;
+
+    // Draw highlighted regions
+    for (var region in regions) {
+      final paint = Paint()
+        ..color = region.color
+        ..style = PaintingStyle.fill;
+      Path path = Path();
+      List<GlobeCoordinates> coords;
+      if (region.type == RegionHighlightType.circle) {
+        coords = [];
+        for (int i = 0; i < 36; i++) {
+          final bearing = i * 10.0;
+          coords.add(offsetCoordinates(
+              region.coordinates.first, region.radius, bearing));
+        }
+      } else {
+        coords = region.coordinates;
+      }
+      final projected = coords
+          .map((c) => getSpherePosition3D(c, radius + 0.5, rotationY, rotationZ))
+          .toList();
+      if (projected.every((v) => v.x > 0)) {
+        for (int i = 0; i < projected.length; i++) {
+          final p = Offset(center.dx + projected[i].y,
+              center.dy - projected[i].z);
+          if (i == 0) {
+            path.moveTo(p.dx, p.dy);
+          } else {
+            path.lineTo(p.dx, p.dy);
+          }
+        }
+        if (path.computeMetrics().isNotEmpty) {
+          path.close();
+          canvas.drawPath(path, paint);
+        }
+      }
+    }
 
     for (var point in points) {
       final pointPaint = Paint()..color = point.style.color;
@@ -132,17 +175,45 @@ class ForegroundPainter extends CustomPainter {
           });
         }
 
-        if ((point.isLabelVisible &&
-                point.label != null &&
-                point.label != '') &&
-            point.labelBuilder == null) {
-          paintText(point.label ?? '', point.labelTextStyle, cartesian2D, size,
-              canvas);
-        }
-      } else {
-        hoverOverPoint(point.id, cartesian2D, false, false);
+      if ((point.isLabelVisible &&
+              point.label != null &&
+              point.label != '') &&
+          point.labelBuilder == null) {
+        paintText(point.label ?? '', point.labelTextStyle, cartesian2D, size,
+            canvas);
+      }
+    } else {
+      hoverOverPoint(point.id, cartesian2D, false, false);
+    }
+  }
+
+    // Draw rods
+    for (var rod in rods) {
+      final startOuter = getSpherePosition3D(
+          rod.start, radius + rod.stickOut, rotationY, rotationZ);
+      final startSurface =
+          getSpherePosition3D(rod.start, radius, rotationY, rotationZ);
+      final endOuter =
+          getSpherePosition3D(rod.end, radius + rod.stickOut, rotationY, rotationZ);
+      final endSurface =
+          getSpherePosition3D(rod.end, radius, rotationY, rotationZ);
+      final paint = Paint()
+        ..color = rod.color
+        ..strokeWidth = rod.width
+        ..strokeCap = StrokeCap.round;
+
+      if (startOuter.x > 0) {
+        final p1 = Offset(center.dx + startOuter.y, center.dy - startOuter.z);
+        final p2 = Offset(center.dx + startSurface.y, center.dy - startSurface.z);
+        canvas.drawLine(p1, p2, paint);
+      }
+      if (endOuter.x > 0) {
+        final p1 = Offset(center.dx + endSurface.y, center.dy - endSurface.z);
+        final p2 = Offset(center.dx + endOuter.y, center.dy - endOuter.z);
+        canvas.drawLine(p1, p2, paint);
       }
     }
+
     for (var connection in connections) {
       Map? info = drawAnimatedLine(canvas, connection, radius, rotationY,
           rotationZ, connection.animationProgress, size, hoverPoint);

--- a/lib/math_helper.dart
+++ b/lib/math_helper.dart
@@ -165,3 +165,21 @@ double adjustModRotation(double rotation) {
   }
   return rotation;
 }
+
+/// Calculates a destination coordinate from [start] given a distance in degrees
+/// and a bearing in degrees.
+GlobeCoordinates offsetCoordinates(
+    GlobeCoordinates start, double distanceDeg, double bearingDeg) {
+  final lat1 = degreesToRadians(start.latitude);
+  final lon1 = degreesToRadians(start.longitude);
+  final brng = degreesToRadians(bearingDeg);
+  final dist = degreesToRadians(distanceDeg);
+
+  final lat2 =
+      asin(sin(lat1) * cos(dist) + cos(lat1) * sin(dist) * cos(brng));
+  final lon2 = lon1 +
+      atan2(sin(brng) * sin(dist) * cos(lat1),
+          cos(dist) - sin(lat1) * sin(lat2));
+
+  return GlobeCoordinates(radiansToDegrees(lat2), radiansToDegrees(lon2));
+}

--- a/lib/region_highlight.dart
+++ b/lib/region_highlight.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+import 'globe_coordinates.dart';
+
+/// Type of region highlight.
+enum RegionHighlightType { polygon, circle }
+
+/// Represents a highlighted region on the globe.
+class RegionHighlight {
+  final String id;
+  final RegionHighlightType type;
+  final List<GlobeCoordinates> coordinates;
+  final double radius;
+  final Color color;
+
+  /// Creates a polygon highlight with the given [coordinates].
+  RegionHighlight.polygon({
+    required this.id,
+    required List<GlobeCoordinates> coordinates,
+    this.color = const Color(0x88FF0000),
+  })  : type = RegionHighlightType.polygon,
+        radius = 0,
+        coordinates = coordinates;
+
+  /// Creates a circular highlight with [center] and [radius] in degrees.
+  RegionHighlight.circle({
+    required this.id,
+    required GlobeCoordinates center,
+    required this.radius,
+    this.color = const Color(0x8844FF44),
+  })  : type = RegionHighlightType.circle,
+        coordinates = [center];
+}

--- a/lib/rod.dart
+++ b/lib/rod.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import 'globe_coordinates.dart';
+
+/// Represents a rod that goes through the globe.
+class Rod {
+  final GlobeCoordinates start;
+  final GlobeCoordinates end;
+  final String id;
+  final Color color;
+  final double width;
+  final double stickOut;
+
+  /// Creates a new [Rod].
+  const Rod({
+    required this.start,
+    required this.end,
+    required this.id,
+    this.color = Colors.white,
+    this.width = 2,
+    this.stickOut = 10,
+  });
+
+  /// Returns a copy of this rod with the given fields replaced.
+  Rod copyWith({
+    GlobeCoordinates? start,
+    GlobeCoordinates? end,
+    String? id,
+    Color? color,
+    double? width,
+    double? stickOut,
+  }) {
+    return Rod(
+      start: start ?? this.start,
+      end: end ?? this.end,
+      id: id ?? this.id,
+      color: color ?? this.color,
+      width: width ?? this.width,
+      stickOut: stickOut ?? this.stickOut,
+    );
+  }
+}

--- a/lib/rotating_globe.dart
+++ b/lib/rotating_globe.dart
@@ -581,6 +581,8 @@ class RotatingGlobeState extends State<RotatingGlobe>
                                     rotationX: rotationX,
                                     zoomFactor: widget.controller.zoom,
                                     points: widget.controller.points,
+                                    rods: widget.controller.rods,
+                                    regions: widget.controller.regions,
                                   ),
                                   painter: SpherePainter(
                                     style: widget.controller.sphereStyle,


### PR DESCRIPTION
## Summary
- add `Rod` and `RegionHighlight` classes
- support rods and highlighted regions in controller and painter
- draw rods and regions in `ForegroundPainter`
- add spherical offset helper
- example updated to demonstrate new features

## Testing
- `dart format` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684782fbc01c832b9dcb4027d7e299f7